### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ With TestMu AI (Formerly LambdaTest), you can run C# Selenium and Playwright tes
 ### Prerequisites
 
 1. .NET SDK (6.0 or higher) installed.
-2. A TestMu AI account — [sign up here](https://www.testmuai.com/register/).
-3. Your TestMu AI Username and Access Key from the [Automation Dashboard](https://automation.testmuai.com/).
+2. A TestMu AI account — sign up here.
+3. Your TestMu AI Username and Access Key from the Automation Dashboard.
 
 ### Setup
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.